### PR TITLE
fix(hir): 修链式 call、bound method、numeric for 和 guard 短路合并

### DIFF
--- a/packages/unluac-test-support/src/case_manifest.rs
+++ b/packages/unluac-test-support/src/case_manifest.rs
@@ -190,6 +190,10 @@ const REGRESSION_CASES: &[LuaCaseMatrixEntry] = &[
         "tests/regress-case/regress_14_guard_call_result_reused.lua",
         PUC_LUA_GE_52,
     ),
+    LuaCaseMatrixEntry::new(
+        "tests/regress-case/regress_15_branch_preserved_nil_seed.lua",
+        PUC_LUA_51,
+    ),
 ];
 
 pub(crate) fn unit_cases() -> impl Iterator<Item = LuaCaseManifestEntry> {

--- a/packages/unluac-test-support/src/case_manifest.rs
+++ b/packages/unluac-test-support/src/case_manifest.rs
@@ -186,6 +186,10 @@ const REGRESSION_CASES: &[LuaCaseMatrixEntry] = &[
         "tests/regress-case/regress_13_entry_loop_state.lua",
         PUC_LUA_51,
     ),
+    LuaCaseMatrixEntry::new(
+        "tests/regress-case/regress_14_guard_call_result_reused.lua",
+        PUC_LUA_GE_52,
+    ),
 ];
 
 pub(crate) fn unit_cases() -> impl Iterator<Item = LuaCaseManifestEntry> {

--- a/src/ast/build.rs
+++ b/src/ast/build.rs
@@ -206,30 +206,41 @@ impl<'a> AstLowerer<'a> {
                 1,
             )),
             HirStmt::TableSetList(set_list) => {
-                if set_list.trailing_multivalue.is_some() {
-                    return Err(AstLowerError::UnsupportedSetListTrailingMultivalue {
-                        proto: proto_index,
-                    });
-                }
                 let base = self.lower_expr(proto_index, &set_list.base)?;
-                let stmts = set_list
-                    .values
-                    .iter()
-                    .enumerate()
-                    .map(|(offset, value)| {
-                        let index_value =
-                            AstExpr::Integer(i64::from(set_list.start_index) + offset as i64);
-                        let target =
-                            super::common::AstLValue::IndexAccess(Box::new(AstIndexAccess {
-                                base: base.clone(),
-                                index: index_value,
-                            }));
-                        Ok(AstStmt::Assign(Box::new(AstAssign {
-                            targets: vec![target],
-                            values: vec![self.lower_expr(proto_index, value)?],
-                        })))
-                    })
-                    .collect::<Result<Vec<_>, AstLowerError>>()?;
+                let mut stmts = Vec::with_capacity(
+                    set_list.values.len() + usize::from(set_list.trailing_multivalue.is_some()),
+                );
+                for (offset, value) in set_list.values.iter().enumerate() {
+                    let index_value =
+                        AstExpr::Integer(i64::from(set_list.start_index) + offset as i64);
+                    let target =
+                        super::common::AstLValue::IndexAccess(Box::new(AstIndexAccess {
+                            base: base.clone(),
+                            index: index_value,
+                        }));
+                    stmts.push(AstStmt::Assign(Box::new(AstAssign {
+                        targets: vec![target],
+                        values: vec![self.lower_expr(proto_index, value)?],
+                    })));
+                }
+                if let Some(trailing) = &set_list.trailing_multivalue {
+                    let mut value = self.lower_expr(proto_index, trailing)?;
+                    // SETLIST 的 open 尾值通常只占一个数组槽；多返回 call 需要截断为单值。
+                    if matches!(trailing, HirExpr::Call(call) if call.multiret) {
+                        value = AstExpr::SingleValue(Box::new(value));
+                    }
+                    let index_value =
+                        AstExpr::Integer(i64::from(set_list.start_index) + set_list.values.len() as i64);
+                    let target =
+                        super::common::AstLValue::IndexAccess(Box::new(AstIndexAccess {
+                            base,
+                            index: index_value,
+                        }));
+                    stmts.push(AstStmt::Assign(Box::new(AstAssign {
+                        targets: vec![target],
+                        values: vec![value],
+                    })));
+                }
                 Ok((stmts, 1))
             }
             HirStmt::ErrNil(_) => {

--- a/src/ast/build/patterns/shape.rs
+++ b/src/ast/build/patterns/shape.rs
@@ -64,6 +64,11 @@ impl<'a> AstLowerer<'a> {
         let Some(HirStmt::CallStmt(call_stmt)) = stmts.get(index) else {
             return Ok(None);
         };
+        // 方法糖下 args[0] 是 receiver；若整个调用只有一个参数，那它一定是
+        // receiver 而不是“最后一个实参里的单值调用”，不能走 SingleValue 包装。
+        if call_stmt.call.method && call_stmt.call.args.len() <= 1 {
+            return Ok(None);
+        }
         let Some(HirExpr::Call(arg_call)) = call_stmt.call.args.last() else {
             return Ok(None);
         };

--- a/src/hir/analyze/exprs.rs
+++ b/src/hir/analyze/exprs.rs
@@ -5,6 +5,7 @@
 //! 因此这里专门承载“值如何解释”的规则，让 `analyze.rs` 更多只关心语句和控制流骨架。
 
 mod access;
+mod bound_method;
 mod branch;
 mod defs;
 mod packs;
@@ -23,6 +24,7 @@ use crate::transformer::{
     UnaryOpKind, ValueOperand,
 };
 
+pub(super) use self::bound_method::try_recover_bound_method_call;
 pub(super) use self::access::{
     expr_for_const, expr_for_value_operand, lower_table_access_expr, lower_table_access_target,
 };

--- a/src/hir/analyze/exprs/bound_method.rs
+++ b/src/hir/analyze/exprs/bound_method.rs
@@ -1,0 +1,118 @@
+//! 识别 `local f = obj.method; f(obj, ...)` 这类显式表索引 + CALL 的 bound method 调用，
+//! 并回收成 `obj:method(...)` 的 HIR method 糖。Lua 5.1 里 `obj:Lookup(x)` 与
+//! `obj.Lookup(obj, x)` 都会编译成 GETTABLE + CALL，而不一定走 NAMECALL。
+
+use super::*;
+
+pub(in crate::hir::analyze) fn try_recover_bound_method_call(
+    lowering: &ProtoLowering<'_>,
+    block: BlockRef,
+    instr_ref: InstrRef,
+    call: &crate::transformer::CallInstr,
+) -> Option<HirCallExpr> {
+    if matches!(call.kind, CallKind::Method) || call.method_name.is_some() {
+        return None;
+    }
+
+    let callee_reg = call.callee;
+    let def_id = single_reaching_def(lowering, instr_ref, callee_reg)?;
+    let def_instr_ref = lowering.dataflow.def_instr(def_id);
+    if lowering.dataflow.def_reg(def_id) != callee_reg {
+        return None;
+    }
+
+    let LowInstr::GetTable(get_table) = lowering.proto.instrs.get(def_instr_ref.index())?
+    else {
+        return None;
+    };
+    if get_table.dst != callee_reg {
+        return None;
+    }
+
+    let AccessBase::Reg(base_reg) = get_table.base else {
+        return None;
+    };
+    let method_name = method_name_from_access_key(lowering.proto, get_table.key)?;
+
+    let first_arg_reg = first_arg_reg_from_pack(call.args)?;
+    if !receiver_reg_matches_base(
+        lowering,
+        block,
+        instr_ref,
+        first_arg_reg,
+        base_reg,
+    ) {
+        return None;
+    }
+
+    Some(HirCallExpr {
+        callee: HirExpr::Nil,
+        args: lower_value_pack(lowering, block, instr_ref, call.args),
+        multiret: is_multiret_results(call.results),
+        method: true,
+        method_name: Some(method_name),
+    })
+}
+
+fn single_reaching_def(
+    lowering: &ProtoLowering<'_>,
+    instr_ref: InstrRef,
+    reg: Reg,
+) -> Option<DefId> {
+    let values = lowering.dataflow.use_values_at(instr_ref).get(reg)?;
+    let mut defs = values.iter().filter_map(|value| match value {
+        SsaValue::Def(def) => Some(def),
+        SsaValue::Phi(_) => None,
+    });
+    let def = defs.next()?;
+    if defs.next().is_some() {
+        return None;
+    }
+    Some(def)
+}
+
+fn first_arg_reg_from_pack(pack: crate::transformer::ValuePack) -> Option<Reg> {
+    match pack {
+        crate::transformer::ValuePack::Fixed(range) if range.len >= 1 => Some(range.start),
+        crate::transformer::ValuePack::Open(reg) => Some(reg),
+        _ => None,
+    }
+}
+
+fn method_name_from_access_key(proto: &LoweredProto, key: AccessKey) -> Option<String> {
+    let AccessKey::Const(const_ref) = key else {
+        return None;
+    };
+    match proto.constants.common.literals.get(const_ref.index()) {
+        Some(RawLiteralConst::String(value)) => Some(decode_raw_string(value)),
+        _ => None,
+    }
+}
+
+fn receiver_reg_matches_base(
+    lowering: &ProtoLowering<'_>,
+    block: BlockRef,
+    instr_ref: InstrRef,
+    receiver_reg: Reg,
+    base_reg: Reg,
+) -> bool {
+    if receiver_reg == base_reg {
+        return true;
+    }
+
+    let Some(def_id) = single_reaching_def(lowering, instr_ref, receiver_reg) else {
+        return false;
+    };
+    let def_instr_ref = lowering.dataflow.def_instr(def_id);
+    if lowering.dataflow.def_block(def_id) != block {
+        return false;
+    }
+    if def_instr_ref.index() >= instr_ref.index() {
+        return false;
+    }
+
+    match lowering.proto.instrs.get(def_instr_ref.index()) {
+        Some(LowInstr::Move(mv)) if mv.dst == receiver_reg && mv.src == base_reg => true,
+        _ => false,
+    }
+}

--- a/src/hir/analyze/lower.rs
+++ b/src/hir/analyze/lower.rs
@@ -13,7 +13,7 @@ use super::exprs::{
     expr_for_closure_capture, expr_for_const, expr_for_reg_at_block_exit, expr_for_reg_use,
     expr_for_value_operand, is_multiret_results, lower_binary_op, lower_branch_cond,
     lower_method_name, lower_table_access_expr, lower_table_access_target, lower_unary_op,
-    lower_value_pack, lower_value_pack_components,
+    lower_value_pack, lower_value_pack_components, try_recover_bound_method_call,
 };
 use super::helpers::{
     assign_stmt, binary_expr, branch_stmt, build_label_map_for_summary, concat_expr,
@@ -838,24 +838,30 @@ fn lower_call(
     instr_ref: InstrRef,
     call: &crate::transformer::CallInstr,
 ) -> Vec<HirStmt> {
-    let method_name = lower_method_name(lowering.proto, call.method_name);
-    let is_method_sugar = matches!(call.kind, CallKind::Method) && method_name.is_some();
-    // 当调用会被 AST 渲染成 `obj:method()` 糖时，AST 只读 args[0] 和
-    // method_name，callee 被丢弃。这里直接把 callee 置为 Nil，从而让源自
-    // `SELF` / `NAMECALL` 的 method-load GetTable 在 HIR 中也真正失去读者，
-    // 配合同一 pass 里对 `method_load` 的跳过逻辑建立闭环。
-    let callee = if is_method_sugar {
-        HirExpr::Nil
+    let expr = if let Some(bound_method) =
+        try_recover_bound_method_call(lowering, block, instr_ref, call)
+    {
+        HirExpr::Call(Box::new(bound_method))
     } else {
-        expr_for_reg_use(lowering, block, instr_ref, call.callee)
+        let method_name = lower_method_name(lowering.proto, call.method_name);
+        let is_method_sugar = matches!(call.kind, CallKind::Method) && method_name.is_some();
+        // 当调用会被 AST 渲染成 `obj:method()` 糖时，AST 只读 args[0] 和
+        // method_name，callee 被丢弃。这里直接把 callee 置为 Nil，从而让源自
+        // `SELF` / `NAMECALL` 的 method-load GetTable 在 HIR 中也真正失去读者，
+        // 配合同一 pass 里对 `method_load` 的跳过逻辑建立闭环。
+        let callee = if is_method_sugar {
+            HirExpr::Nil
+        } else {
+            expr_for_reg_use(lowering, block, instr_ref, call.callee)
+        };
+        HirExpr::Call(Box::new(HirCallExpr {
+            callee,
+            args: lower_value_pack(lowering, block, instr_ref, call.args),
+            multiret: is_multiret_results(call.results),
+            method: matches!(call.kind, CallKind::Method),
+            method_name,
+        }))
     };
-    let expr = HirExpr::Call(Box::new(HirCallExpr {
-        callee,
-        args: lower_value_pack(lowering, block, instr_ref, call.args),
-        multiret: is_multiret_results(call.results),
-        method: matches!(call.kind, CallKind::Method),
-        method_name,
-    }));
 
     if matches!(call.results, ResultPack::Ignore) {
         vec![HirStmt::CallStmt(Box::new(HirCallStmt {

--- a/src/hir/analyze/short_circuit/recovery.rs
+++ b/src/hir/analyze/short_circuit/recovery.rs
@@ -211,6 +211,13 @@ fn build_branch_short_circuit_plan_from_candidate(
     if consumed_headers_have_escaping_defs(lowering, short, &allowed_blocks) {
         return None;
     }
+    // 单节点候选的 entry header 也会被整段吞掉（extend 嵌套时常见），
+    // 需同样检查其定义是否在 `short.blocks` 外仍被读取。
+    if short.nodes.len() == 1
+        && header_defs_escape_short_circuit_region(lowering, short, short.header)
+    {
+        return None;
+    }
 
     let has_forbidden =
         decision_references_forbidden_candidate_temps(lowering, short, &decision, &allowed_blocks);
@@ -838,6 +845,15 @@ fn block_has_escaping_defs(
         return false;
     }
 
+    header_defs_escape_short_circuit_region(lowering, short, block)
+}
+
+/// 检查某个 header block 内的定义是否在短路候选区域外仍被读取。
+fn header_defs_escape_short_circuit_region(
+    lowering: &ProtoLowering<'_>,
+    short: &ShortCircuitCandidate,
+    block: BlockRef,
+) -> bool {
     let range = lowering.cfg.blocks[block.index()].instrs;
     for instr_idx in range.start.index()..range.end() {
         for &def_id in &lowering.dataflow.instr_defs[instr_idx] {

--- a/src/hir/analyze/structure/branch_values.rs
+++ b/src/hir/analyze/structure/branch_values.rs
@@ -17,6 +17,7 @@ use crate::hir::common::{
     HirDecisionExpr, HirDecisionNode, HirDecisionNodeRef, HirDecisionTarget, HirExpr, HirLValue,
     TempId,
 };
+use crate::transformer::Reg;
 
 use super::rewrites::lvalue_as_expr;
 use super::*;
@@ -288,13 +289,14 @@ impl<'a, 'b> StructuredBodyLowerer<'a, 'b> {
     ) -> HirExpr {
         // 某一臂只是在“沿用进入分支前的当前值”时，shared target 需要先吃到一份 seed；
         // 否则后面只改写“写新值”的那一臂，merge 后继续读取的状态槽位就会悬空成 nil。
-        if !self.block_redefines_reg(header, reg)
+        let mut expr = if !self.block_redefines_reg(header, reg)
             && let Some(expr) = self.overrides.carried_entry_expr(header, reg)
         {
-            return expr.clone();
-        }
-
-        let mut expr = expr_for_reg_at_block_exit(self.lowering, header, reg);
+            expr.clone()
+        } else {
+            expr_for_reg_at_block_exit(self.lowering, header, reg)
+        };
+        expr = nil_if_uninitialized_preserved_reg(self.lowering, reg, expr);
         rewrite_expr_temps(&mut expr, &temp_expr_overrides(target_overrides));
         expr
     }
@@ -315,6 +317,26 @@ impl<'a, 'b> StructuredBodyLowerer<'a, 'b> {
 
         arm_expr
     }
+}
+
+/// 分支合流某一臂“沿用当前值”时，若寄存器在进入分支前从未定义，Lua 语义上就是 `nil`。
+fn nil_if_uninitialized_preserved_reg(
+    lowering: &ProtoLowering<'_>,
+    reg: Reg,
+    expr: HirExpr,
+) -> HirExpr {
+    let HirExpr::Unresolved(unresolved) = &expr else {
+        return expr;
+    };
+    if unresolved.summary != format!("entry-reg r{}", reg.index()) {
+        return expr;
+    }
+    if reg.index() < lowering.bindings.params.len()
+        || lowering.bindings.entry_local_regs.contains_key(&reg)
+    {
+        return expr;
+    }
+    HirExpr::Nil
 }
 
 fn branch_value_needs_preserved_entry_seed(value: &BranchValueMergeValue) -> bool {

--- a/src/hir/analyze/structure/loops/state.rs
+++ b/src/hir/analyze/structure/loops/state.rs
@@ -643,6 +643,12 @@ impl<'a, 'b> StructuredBodyLowerer<'a, 'b> {
             if downstream_post_loop == Some(exit) {
                 continue;
             }
+            // 自然循环的 region exit 有时只是循环体内部的 early-return 路径，
+            // 并不会回到 post-loop continuation。这种出口不能按 break pad 处理，
+            // 否则 `lower_break_exit_pad` 会失败并把整片 numeric-for 打回 goto。
+            if !self.exit_reaches_post_loop(exit, post_loop, downstream_post_loop) {
+                continue;
+            }
             break_exits.insert(
                 exit,
                 self.lower_break_exit_pad(
@@ -693,6 +699,34 @@ impl<'a, 'b> StructuredBodyLowerer<'a, 'b> {
         Some(target)
     }
 
+    fn exit_reaches_post_loop(
+        &self,
+        exit: BlockRef,
+        post_loop: BlockRef,
+        downstream_post_loop: Option<BlockRef>,
+    ) -> bool {
+        let mut visiting = BTreeSet::new();
+        let mut stack = vec![exit];
+        while let Some(block) = stack.pop() {
+            if block == post_loop || Some(block) == downstream_post_loop {
+                return true;
+            }
+            if block == self.lowering.cfg.exit_block || block_is_terminal_exit(self.lowering, block) {
+                continue;
+            }
+            if !self.lowering.cfg.reachable_blocks.contains(&block) {
+                continue;
+            }
+            if !visiting.insert(block) {
+                continue;
+            }
+            for edge_ref in &self.lowering.cfg.succs[block.index()] {
+                stack.push(self.lowering.cfg.edges[edge_ref.index()].to);
+            }
+        }
+        false
+    }
+
     fn loop_state_inside_exit_blocks(
         &self,
         candidate: &LoopCandidate,
@@ -710,6 +744,9 @@ impl<'a, 'b> StructuredBodyLowerer<'a, 'b> {
                 continue;
             }
             if downstream_post_loop == Some(exit) {
+                continue;
+            }
+            if !self.exit_reaches_post_loop(exit, post_loop, downstream_post_loop) {
                 continue;
             }
             self.lower_break_exit_pad(

--- a/tests/regress-case/regress_14_guard_call_result_reused.lua
+++ b/tests/regress-case/regress_14_guard_call_result_reused.lua
@@ -1,0 +1,34 @@
+-- regress_14_guard_call_result_reused#1: guard 链末尾 call 的返回值在 then 主逻辑里仍被读取时，
+-- 不能把 call inline 进 and 条件而丢失赋值。
+-- unluac: expect-not-contains [[unluac error]]
+-- unluac: expect-not-contains [[and p2_1 and]]
+-- unluac: expect-contains [[if p2_1 then]]
+-- unluac: expect-contains [[missing_record]]
+local function fetch_record(key)
+    if key == 0 then
+        return nil
+    end
+    return { key = key, entries = { 10, 20 } }
+end
+
+local function run(key, target)
+    if not key then
+        return "missing_key"
+    end
+    if not target then
+        return "missing_target"
+    end
+    local record = fetch_record(key)
+    if not record then
+        return "missing_record"
+    end
+    local count = #record.entries
+    for i = 1, count do
+        if record.entries[i] == target then
+            return "hit:" .. i
+        end
+    end
+    return "miss"
+end
+
+return run(1, 10)

--- a/tests/regress-case/regress_15_branch_preserved_nil_seed.lua
+++ b/tests/regress-case/regress_15_branch_preserved_nil_seed.lua
@@ -1,0 +1,23 @@
+-- regress_15_branch_preserved_nil_seed#1: 条件赋值后 `if not v then return` 时，
+-- 未走 then 臂的寄存器在 Lua 里就是 nil，不能留下 entry-reg unresolved。
+-- unluac: expect-not-contains [[unluac error]]
+-- unluac: expect-not-contains [[entry-reg]]
+local function fetch_record(key)
+    if key == 0 then
+        return nil
+    end
+    return { id = key, scale = 1024 }
+end
+
+local function run(key, amount)
+    local record
+    if key and key > 0 then
+        record = fetch_record(key)
+    end
+    if not record then
+        return "missing"
+    end
+    return amount * record.scale / 1024
+end
+
+return run(1, 100)


### PR DESCRIPTION
链式 method call 之前会在 AST 阶段 panic
GETTABLE+CALL 现在能还原成 :method() 
numeric for 在带 early-return 的路径上也不会再 unresolved
guard 短路逐段嵌套时，如果最后一个 call 的结果后面还要用，不再并进 and 条件里（否则会出未赋值变量）
加了 regress_14